### PR TITLE
propara docs

### DIFF
--- a/propara/README.md
+++ b/propara/README.md
@@ -1,6 +1,6 @@
 # ProPara
 
-* [evaluator](evaluator/) is the program used by the [AI2 ProPara Leaderboard](https://leaderboard.allenai.org/) to evaluate submitted predictions.
+* [evaluator](evaluator/) is the program used by the [ProPara Leaderboard](https://leaderboard.allenai.org/) to evaluate submitted predictions.
 * [data](data/) contains dev, train and test datasets
 
 ## Example usage

--- a/propara/data/README.md
+++ b/propara/data/README.md
@@ -4,7 +4,7 @@ This directory contains dev, train and test datasets.
   
   * [dev](dev/) contains the dev dataset for developing your predictor
   * [train](train/) contains the training dataset for evaluating your predictor during development
-  * [test](test/) contains the test dataset for evaluation on the [AI2 ProPara Leaderboard](https://leaderboard.allenai.org/).
+  * [test](test/) contains the test dataset for evaluation on the [ProPara Leaderboard](https://leaderboard.allenai.org/).
 
 Each subdirectory contains `answers.tsv` and `dummy-predictions.tsv` files. In
 addition each has a `sentences.tsv` file as a convenience to discover the

--- a/propara/evaluator/README.md
+++ b/propara/evaluator/README.md
@@ -26,7 +26,7 @@ Evaluated 54 predictions against 54 answers.
 ## Usage
 
 The script requires prediction and answer input files, and produces a report to
-standard out.
+standard out. You'll need Python 3.6 or newer to run it.
 
 Optional:
 

--- a/propara/evaluator/README.md
+++ b/propara/evaluator/README.md
@@ -30,9 +30,9 @@ standard out. You'll need Python 3.6 or newer to run it.
 
 Optional:
 
-* the flag `--output` writes the overall precision, recall and F1 score to a JSON file.
-* the flag `--diagnostics` writes a diagnostic file with process summaries (an intermediate representation of each process) and their scores.
-* the flag `--sentences` reads sentences from a sentences file and includes them in the diagnostics file. See [sentences.tsv files in the ../data directory](../data/).
+* the argument `--output` writes the overall precision, recall and F1 score to a JSON file.
+* the argument `--diagnostics` writes a diagnostic file with process summaries (an intermediate representation of each process) and their scores.
+* the argument `--sentences` reads sentences from a sentences file and includes them in the diagnostics file. See [sentences.tsv files in the ../data directory](../data/).
 
 ## Evaluation process
 


### PR DESCRIPTION
Added a note that Python 3.6 is required, and some minor doc updates.