### PR TITLE
remove need for explicit env vars in docker invocation

### DIFF
--- a/eqasc/README.md
+++ b/eqasc/README.md
@@ -14,8 +14,6 @@ test dataset, run this and look at the scores in the file /tmp/metrics.json:
 cd code
 docker build -t eqasc-evaluator .
 docker run \
-  -e PYTHONPATH=. \
-  -e PYTHONUNBUFFERED=yes \
   -v /tmp/predictions.txt:/predictions.txt:ro \
   -v $PWD/../data:/labels:ro \
   -v /tmp:/output:rw \

--- a/eqasc/code/Dockerfile
+++ b/eqasc/code/Dockerfile
@@ -2,4 +2,6 @@ FROM python:3.6.8
 RUN pip install numpy==1.19.2
 RUN pip install scikit-learn==0.23.2
 WORKDIR /eqasc
+ENV PYTHONPATH .
+ENV PYTHONUNBUFFERED yes
 COPY allennlp_reasoning_explainqa /eqasc/allennlp_reasoning_explainqa

--- a/eqasc/code/README.md
+++ b/eqasc/code/README.md
@@ -80,8 +80,6 @@ Then run it with the above files like this:
 
 ```
 docker run \
-  -e PYTHONPATH=. \
-  -e PYTHONUNBUFFERED=yes \
   -v $PWD/predictions:/predictions:ro \
   -v $PWD/../data:/labels:ro \
   -v /tmp:/output:rw \

--- a/eqasc/code/test-with-docker.sh
+++ b/eqasc/code/test-with-docker.sh
@@ -21,8 +21,6 @@ tempdir=$(mktemp -d /tmp/temp.XXXX)
 
 set -x
 docker run \
-  -e PYTHONPATH=. \
-  -e PYTHONUNBUFFERED=yes \
   -v $PWD/predictions:/predictions:ro \
   -v $PWD/../data:/labels:ro \
   -v $tempdir:/output:rw \


### PR DESCRIPTION
This will make it possible to run the evaluator in Leaderboard, where env vars can't be specified at runtime.